### PR TITLE
Copy assets when build[ing]-npm-modules, and bind StudyAccessApi methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Dave Falke <dmfalke@gmail.com>",
   "license": "Apache-2.0",
   "scripts": {
-    "build-npm-modules": "tsc -p tsconfig.build.json"
+    "build-npm-modules": "veupathdb-react-scripts prepare src lib"
   },
   "typings": "./lib/index.d.ts",
   "eslintConfig": {
@@ -26,6 +26,7 @@
     "@veupathdb/browserslist-config": "^1.0.0",
     "@veupathdb/eslint-config": "^1.0.0",
     "@veupathdb/prettier-config": "^1.0.0",
+    "@veupathdb/react-scripts": "^1.2.0",
     "@veupathdb/tsconfig": "^1.0.1",
     "husky": ">=4",
     "lint-staged": ">=10",

--- a/src/study-access/api.ts
+++ b/src/study-access/api.ts
@@ -4,7 +4,7 @@ import {
   createJsonRequest,
   ApiRequest,
   FetchClient,
-  ioTransformer
+  ioTransformer,
 } from '@veupathdb/http-utils';
 import {
   ApprovalStatus,
@@ -37,7 +37,7 @@ const HISTORY_PATH = '/history';
 
 export class StudyAccessApi extends FetchClient {
 
-  fetch<T>(apiRequest: ApiRequest<T>) {
+  fetch = <T>(apiRequest: ApiRequest<T>) => {
     const wdkCheckAuth = document.cookie.split('; ').find(x => x.startsWith('wdk_check_auth=')) ?? '';
     const authKey = wdkCheckAuth.replace('wdk_check_auth=', '');  
     return super.fetch({
@@ -49,7 +49,7 @@ export class StudyAccessApi extends FetchClient {
     })
   }
 
-  fetchStaffList(limit?: number, offset?: number) {
+  fetchStaffList = (limit?: number, offset?: number) => {
     const queryString = makeQueryString(
       ['limit', 'offset'],
       [limit, offset]
@@ -62,7 +62,7 @@ export class StudyAccessApi extends FetchClient {
     }));
   }
 
-  createStaffEntry(requestBody: NewStaffRequest) {
+  createStaffEntry = (requestBody: NewStaffRequest) => {
     return this.fetch(createJsonRequest({
       path: STAFF_PATH,
       method: 'POST',
@@ -71,7 +71,7 @@ export class StudyAccessApi extends FetchClient {
     }));
   }
 
-  updateStaffEntry(staffId: number, requestBody: StaffPatch) {
+  updateStaffEntry = (staffId: number, requestBody: StaffPatch) => {
     return this.fetch(createJsonRequest({
       path: `${STAFF_PATH}/${staffId}`,
       method: 'PATCH',
@@ -80,7 +80,7 @@ export class StudyAccessApi extends FetchClient {
     }));
   }
 
-  deleteStaffEntry(staffId: number) {
+  deleteStaffEntry = (staffId: number) => {
     return this.fetch({
       path: `${STAFF_PATH}/${staffId}`,
       method: 'DELETE',
@@ -88,7 +88,7 @@ export class StudyAccessApi extends FetchClient {
     });
   }
 
-  fetchProviderList(datasetId: string, limit?: number, offset?: number) {
+  fetchProviderList = (datasetId: string, limit?: number, offset?: number) => {
     const queryString = makeQueryString(
       ['datasetId', 'limit', 'offset'],
       [datasetId, limit, offset]
@@ -101,7 +101,7 @@ export class StudyAccessApi extends FetchClient {
     });
   }
 
-  createProviderEntry(requestBody: DatasetProviderCreateRequest) {
+  createProviderEntry = (requestBody: DatasetProviderCreateRequest) => {
     return this.fetch(createJsonRequest({
       path: PROVIDERS_PATH,
       method: 'POST',
@@ -110,7 +110,7 @@ export class StudyAccessApi extends FetchClient {
     }));
   }
 
-  updateProviderEntry(providerId: number, requestBody: DatasetProviderPatch) {
+  updateProviderEntry = (providerId: number, requestBody: DatasetProviderPatch) => {
     return this.fetch(createJsonRequest({
       path: `${PROVIDERS_PATH}/${providerId}`,
       method: 'PATCH',
@@ -119,7 +119,7 @@ export class StudyAccessApi extends FetchClient {
     }));
   }
 
-  deleteProviderEntry(providerId: number) {
+  deleteProviderEntry = (providerId: number) => {
     return this.fetch({
       path: `${PROVIDERS_PATH}/${providerId}`,
       method: 'DELETE',
@@ -127,7 +127,7 @@ export class StudyAccessApi extends FetchClient {
     });
   }
 
-  fetchEndUserList(datasetId: string, limit?: number, offset?: number, approval?: ApprovalStatus) {
+  fetchEndUserList = (datasetId: string, limit?: number, offset?: number, approval?: ApprovalStatus) => {
     const queryString = makeQueryString(
       ['datasetId', 'limit', 'offset', 'approval'],
       [datasetId, limit, offset, approval]
@@ -140,7 +140,7 @@ export class StudyAccessApi extends FetchClient {
     });
   }
 
-  createEndUserEntry(requestBody: EndUserCreateRequest) {
+  createEndUserEntry = (requestBody: EndUserCreateRequest) => {
     return this.fetch(createJsonRequest({
       path: END_USERS_PATH,
       method: 'POST',
@@ -149,7 +149,7 @@ export class StudyAccessApi extends FetchClient {
     }));
   }
 
-  fetchEndUserEntry(wdkUserId: number, datasetId: string) {
+  fetchEndUserEntry = (wdkUserId: number, datasetId: string) => {
     const endUserId = makeEndUserId(
       wdkUserId,
       datasetId
@@ -162,7 +162,7 @@ export class StudyAccessApi extends FetchClient {
     });
   }
 
-  updateEndUserEntry(wdkUserId: number, datasetId: string, requestBody: EndUserPatch) {
+  updateEndUserEntry = (wdkUserId: number, datasetId: string, requestBody: EndUserPatch) => {
     const endUserId = makeEndUserId(
       wdkUserId,
       datasetId
@@ -176,7 +176,7 @@ export class StudyAccessApi extends FetchClient {
     }));
   }
 
-  deleteEndUserEntry(wdkUserId: number, datasetId: string) {
+  deleteEndUserEntry = (wdkUserId: number, datasetId: string) => {
     const endUserId = makeEndUserId(
       wdkUserId,
       datasetId
@@ -189,7 +189,7 @@ export class StudyAccessApi extends FetchClient {
     });
   }
 
-  fetchPermissions() {
+  fetchPermissions = () => {
     return this.fetch({
       path: PERMISSIONS_PATH,
       method: 'GET',
@@ -197,7 +197,7 @@ export class StudyAccessApi extends FetchClient {
     });
   }
 
-  fetchHistory() {
+  fetchHistory = () => {
     return this.fetch({
       path: HISTORY_PATH,
       method: 'GET',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,6 +2875,17 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/prettier-config/-/prettier-config-1.0.0.tgz#6c138be7ce1c4418c7cac5609acdbc5e98bad94c"
   integrity sha512-opFJ858b0dHwHpnRbNBNfm/IXGU7RDs8EHce442YfeY1vkPkX+bE4cJgpaBZ2jrXkUDGb6+w1lqy7Ow0Y74vOQ==
 
+"@veupathdb/react-scripts@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@veupathdb/react-scripts/-/react-scripts-1.2.0.tgz#3aef2d9c4c9d3ca7b8c33ca43cf22419896e90a5"
+  integrity sha512-Pl8cF2gA2sHVnYGuGtTDP+T4Vpi4jzfNrcFyGpbhJ4f1afF0wkkzvWmVlTFJXULeV85Y/brQWF9XkPlciOKmmA==
+  dependencies:
+    dotenv "^8.2.0"
+    fs-extra "^9.1.0"
+    react-app-rewired "^2.1.8"
+    read "^1.0.7"
+    set-cookie-parser "^2.4.6"
+
 "@veupathdb/tsconfig@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@veupathdb/tsconfig/-/tsconfig-1.0.1.tgz#a2b748b46838af1337ca9f23d969993fb952def4"
@@ -6206,6 +6217,11 @@ dotenv@8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 double-bits@^1.1.0, double-bits@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/double-bits/-/double-bits-1.1.1.tgz#58abba45494da4d0fa36b73ad11a286c9184b1c6"
@@ -7279,7 +7295,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -10593,6 +10609,11 @@ murmurhash-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
   integrity sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=
 
+mute-stream@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 nan@^2.12.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
@@ -12633,6 +12654,13 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-app-rewired@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.8.tgz#e192f93b98daf96889418d33d3e86cf863812b56"
+  integrity sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==
+  dependencies:
+    semver "^5.6.0"
+
 react-autocomplete@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/react-autocomplete/-/react-autocomplete-1.8.1.tgz#ebbbc400006aa91ad538b2d14727b9e7e5d06310"
@@ -12954,6 +12982,13 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+read@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
+  dependencies:
+    mute-stream "~0.0.4"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
@@ -13791,6 +13826,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.6:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
+  integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This PR:

1. Updates `build-npm-modules` to also copy JS assets
2. Binds the methods of `StudyAccessApi`, so that they can be passed as callbacks