### PR TITLE
Change hardcoded service url

### DIFF
--- a/src/study-access/api.ts
+++ b/src/study-access/api.ts
@@ -26,7 +26,7 @@ import {
 } from './EntityTypes';
 
 // FIXME: This should be configurable
-export const STUDY_ACCESS_SERVICE_URL = '/dataset-access';
+export const STUDY_ACCESS_SERVICE_URL = '/eda';
 
 // API  defined in https://veupathdb.github.io/service-dataset-access/api.html
 const STAFF_PATH = '/staff';


### PR DESCRIPTION
This is a quick and dirty fix to use the dataset access service that is deployed as a part of the eda stack. I had started to make the service url configurable, but it's not trivial and I'm not confident I can complete that work before build 55 is release. It should be done as a follow-up, however.