### PR TITLE
/permissions-based data restriction checks + configurable study access url

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yarn": "1.22.10"
   },
   "dependencies": {
-    "@veupathdb/http-utils": "^1.0.0",
+    "@veupathdb/http-utils": "^1.0.1",
     "@veupathdb/wdk-client": "^0.4.6",
     "fp-ts": "^2.11.5",
     "io-ts": "^2.2.16",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@veupathdb/http-utils": "^1.0.1",
-    "@veupathdb/wdk-client": "^0.4.6",
+    "@veupathdb/wdk-client": "^0.4.12",
     "fp-ts": "^2.11.5",
     "io-ts": "^2.2.16",
     "lodash": "^4.17.21"

--- a/src/data-restriction/DataRestrictionActionCreators.ts
+++ b/src/data-restriction/DataRestrictionActionCreators.ts
@@ -26,7 +26,7 @@ export function attemptAction(action: DataRestrictionActionType, details: Action
     const studies$ = fetchStudies(wdkService);
 
     return Promise.all([ user$, studies$ ]).then(([ user, studies ]) => {
-      return checkPermissions(user).then(permissions => {
+      return checkPermissions(user, wdkService).then(permissions => {
         return handleAction(
           permissions,
           // FIXME: Either properly type the approvedStudies property, or retire it

--- a/src/data-restriction/DataRestrictionActionCreators.ts
+++ b/src/data-restriction/DataRestrictionActionCreators.ts
@@ -1,6 +1,6 @@
-import { ActionCreatorServices } from '@veupathdb/wdk-client/lib/Core/WdkMiddleware';
 import { makeActionCreator, InferAction } from '@veupathdb/wdk-client/lib/Utils/ActionCreatorUtils';
 import { fetchStudies, getStudyId, Study } from '../shared/studies';
+import { WdkDependenciesWithStudyAccessApi } from '../shared/wrapWdkDependencies';
 
 import { checkPermissions, UserPermissions } from '../study-access/permission';
 
@@ -21,12 +21,12 @@ export interface ActionAttemptDetails {
 }
 
 export function attemptAction(action: DataRestrictionActionType, details: ActionAttemptDetails) {
-  return function run({ wdkService }: ActionCreatorServices) {
+  return function run({ wdkService, studyAccessApi }: WdkDependenciesWithStudyAccessApi) {
     const user$ = wdkService.getCurrentUser();
     const studies$ = fetchStudies(wdkService);
 
     return Promise.all([ user$, studies$ ]).then(([ user, studies ]) => {
-      return checkPermissions(user, wdkService).then(permissions => {
+      return checkPermissions(user, studyAccessApi).then(permissions => {
         return handleAction(
           permissions,
           // FIXME: Either properly type the approvedStudies property, or retire it

--- a/src/data-restriction/DataRestrictionModal.jsx
+++ b/src/data-restriction/DataRestrictionModal.jsx
@@ -39,7 +39,7 @@ class DataRestrictionModal extends React.Component {
 
   renderPolicyNotice () {
     const { study, user, permissions, action, webAppUrl } = this.props;
-    const message = getRestrictionMessage({ study, action });
+    const message = getRestrictionMessage({ action, permissions, study, user });
     const policyUrl = getPolicyUrl(study, webAppUrl);
     return (isPrereleaseStudy(getStudyAccess(study), getStudyId(study), user, permissions))
       ? null
@@ -64,7 +64,7 @@ class DataRestrictionModal extends React.Component {
   renderButtons () {
     const { action, study, user, permissions, showLoginForm, onClose, webAppUrl } = this.props;
     const strict = isActionStrict(action);
-    const approvalRequired = actionRequiresApproval({ action, study });
+    const approvalRequired = actionRequiresApproval({ action, permissions, study, user });
     return (isPrereleaseStudy(getStudyAccess(study), getStudyId(study), user, permissions))
       ? (
         <div className="DataRestrictionModal-Buttons">

--- a/src/data-restriction/DataRestrictionUiActions.ts
+++ b/src/data-restriction/DataRestrictionUiActions.ts
@@ -1,0 +1,53 @@
+// Data stuff =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// per https://docs.google.com/presentation/d/1Cmf2GcmGuKbSTcH4wdeTEvRHTi9DDoh5-MnPm1MkcEA/edit?pli=1#slide=id.g3d955ef9d5_3_2
+
+import { ActionAuthorization } from '../study-access/EntityTypes';
+
+// Actions
+// -------
+export const Action = {
+  // Access Search page
+  search: 'search',
+  // Use a step or column analysis tool
+  analysis: 'analysis',
+  // Run a strategy
+  results: 'results',
+  // View beyond first 20 records
+  paginate: 'paginate',
+  // Click record page link in results page
+  record: 'record',
+  // Access a record page
+  recordPage: 'recordPage',
+  // Access download page
+  downloadPage: 'downloadPage',
+  // Click download link in results page or homepage
+  download: 'download',
+  // Use the basket
+  basket: 'basket',
+} as const;
+
+type ValueOf<T> = T[keyof T];
+
+export type Action = ValueOf<typeof Action>;
+
+// strictActions will popup: "go home" (this is a forbidden page)
+// non strict actions (clicked on link to do something) will popup: "dismiss" (you may stay in this page)
+export const strictActions = new Set([
+  Action.search,
+  Action.analysis,
+  Action.results,
+  Action.recordPage,
+  Action.downloadPage
+]);
+
+export const actionCategories: Record<Action, keyof ActionAuthorization> = {
+  [Action.search]: 'subsetting',
+  [Action.analysis]: 'subsetting',
+  [Action.results]: 'visualizations',
+  [Action.paginate]: 'resultsAll',
+  [Action.record]: 'resultsAll',
+  [Action.recordPage]: 'resultsAll',
+  [Action.downloadPage]: 'resultsAll',
+  [Action.download]: 'resultsAll',
+  [Action.basket]: 'resultsAll',
+};

--- a/src/data-restriction/DataRestrictionUtils.js
+++ b/src/data-restriction/DataRestrictionUtils.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { BasketActions, ResultPanelActions, ResultTableSummaryViewActions } from '@veupathdb/wdk-client/lib/Actions';
 import { attemptAction } from './DataRestrictionActionCreators';
 import {getResultTypeDetails} from '@veupathdb/wdk-client/lib/Utils/WdkResult';
-import { isUserApprovedForStudy } from '../study-access/permission';
+import { isUserFullyApprovedForStudy } from '../study-access/permission';
 import { getStudyAccess, getStudyId, getStudyPolicyUrl, getStudyRequestNeedsApproval } from '../shared/studies';
 
 // Data stuff =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -184,7 +184,7 @@ export function isAllowedAccess ({ permissions, approvedStudies, action, study }
   const id = getStudyId(study);
   if (sessionStorage.getItem('restriction_override') === 'true') return true;
   if (!(access in accessLevels)) throw new Error(`Unknown access level "${access}".`);
-  if (isUserApprovedForStudy(permissions, approvedStudies, id)) return true;
+  if (isUserFullyApprovedForStudy(permissions, approvedStudies, id)) return true;
   if (accessLevels[access][action] === Require.allow) return true;
   //if (accessLevels[study.access][action] === Require.login) if (!user.isGuest) return true;
   // access not allowed, we need to build the modal popup
@@ -206,7 +206,7 @@ export function isPrereleaseStudy (access, studyId, user, permissions) {
     if (permissions != null) {
       if (
         access === 'prerelease' &&
-        !isUserApprovedForStudy(permissions, user.properties.approvedStudies, studyId)
+        !isUserFullyApprovedForStudy(permissions, user.properties.approvedStudies, studyId)
       ) {
         return true;
       } else {

--- a/src/data-restriction/Permissions.tsx
+++ b/src/data-restriction/Permissions.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { UserPermissions } from '../study-access/permission';
+import { usePermissions } from '../data-restriction/permissionsHooks';
+
+/**
+ * This higher-order component fetches the user's UserPermissions and
+ * passes them to the "Component".
+ *
+ * Note: rendering of the "Component" is deferred until the fetch is
+ * complete. Prefer to invoke "usePermissions" within the
+ * "Component" whenever the "Component" should be rendered concurrently
+ * with the fetching of the UserPermissions.
+ */
+ export function withPermissions<P>(Component: React.ComponentType<P & { permissions: UserPermissions }>): React.ComponentType<P> {
+  return function(props) {
+    const permissionsValue = usePermissions();
+
+    return permissionsValue.loading
+      ? null
+      : <Component {...props} permissions={permissionsValue.permissions} />;
+  }
+}

--- a/src/data-restriction/dataRestrictionHooks.ts
+++ b/src/data-restriction/dataRestrictionHooks.ts
@@ -8,12 +8,6 @@ import {
 import { useDispatch } from 'react-redux';
 
 import {
-  useNonNullableContext
-} from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
-import {
-  WdkDepdendenciesContext
-} from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
-import {
   Unpack,
   constant,
   decode,
@@ -22,6 +16,8 @@ import {
   string
 } from '@veupathdb/wdk-client/lib/Utils/Json';
 import { Task } from '@veupathdb/wdk-client/lib/Utils/Task';
+
+import { useWdkDependenciesWithStudyAccessApi } from '../shared/wdkDependencyHook';
 
 import {
   Action as DataRestrictionAction,
@@ -121,7 +117,7 @@ export function useAttemptActionTask<E>(
   action: string
 ): Task<CompleteApprovalStatus, E> {
   const dispatch = useDispatch();
-  const wdkDependencies = useNonNullableContext(WdkDepdendenciesContext);
+  const wdkDependencies = useWdkDependenciesWithStudyAccessApi();
 
   return useMemo(
     () =>
@@ -160,7 +156,7 @@ export function useAttemptActionTask<E>(
 
 export function useAttemptActionCallback() {
   const dispatch = useDispatch();
-  const wdkDependencies = useNonNullableContext(WdkDepdendenciesContext);
+  const wdkDependencies = useWdkDependenciesWithStudyAccessApi();
 
   return useCallback(async (
     action: string,

--- a/src/data-restriction/permissionsHooks.ts
+++ b/src/data-restriction/permissionsHooks.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { defaultMemoize } from 'reselect';
 
+import { WdkService } from '@veupathdb/wdk-client/lib/Core';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
@@ -11,13 +12,19 @@ export type AsyncUserPermissions =
   | { loading: true }
   | { loading: false, permissions: UserPermissions };
 
-const memoizedPermissionsCheck = defaultMemoize(function (user: User) {
-  return checkPermissions(user);
+const memoizedPermissionsCheck = defaultMemoize(function (
+  user: User,
+  wdkService: WdkService
+) {
+  return checkPermissions(user, wdkService);
 });
 
 export function usePermissions(): AsyncUserPermissions {
   const permissions = useWdkService(
-    async wdkService => memoizedPermissionsCheck(await wdkService.getCurrentUser()),
+    async wdkService => memoizedPermissionsCheck(
+      await wdkService.getCurrentUser(),
+      wdkService
+    ),
     []
   );
 

--- a/src/data-restriction/permissionsHooks.ts
+++ b/src/data-restriction/permissionsHooks.ts
@@ -2,11 +2,12 @@ import { useMemo } from 'react';
 
 import { defaultMemoize } from 'reselect';
 
-import { WdkService } from '@veupathdb/wdk-client/lib/Core';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
+import { StudyAccessApi } from '../study-access/api';
 import { UserPermissions, checkPermissions } from '../study-access/permission';
+import { useStudyAccessApi } from '../study-access/studyAccessHooks';
 
 export type AsyncUserPermissions =
   | { loading: true }
@@ -14,18 +15,20 @@ export type AsyncUserPermissions =
 
 const memoizedPermissionsCheck = defaultMemoize(function (
   user: User,
-  wdkService: WdkService
+  studyAccessApi: StudyAccessApi
 ) {
-  return checkPermissions(user, wdkService);
+  return checkPermissions(user, studyAccessApi);
 });
 
 export function usePermissions(): AsyncUserPermissions {
+  const studyAccessApi = useStudyAccessApi();
+
   const permissions = useWdkService(
     async wdkService => memoizedPermissionsCheck(
       await wdkService.getCurrentUser(),
-      wdkService
+      studyAccessApi
     ),
-    []
+    [studyAccessApi]
   );
 
   return useMemo(

--- a/src/shared/wdkDependencyHook.ts
+++ b/src/shared/wdkDependencyHook.ts
@@ -1,0 +1,16 @@
+import { makeUseRefinedContext } from '@veupathdb/wdk-client/lib/Hooks/RefinedContext';
+import { WdkDepdendenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
+
+import { areCompatibleWdkDependencies } from './wrapWdkDependencies';
+
+const useRefinedWdkDependenciesContext = makeUseRefinedContext(
+  areCompatibleWdkDependencies,
+  _ => (
+    'In order to use data restrictions, ' +
+    'a study access API must be included in the WDK dependencies.'
+  )
+);
+
+export function useWdkDependenciesWithStudyAccessApi() {
+  return useRefinedWdkDependenciesContext(WdkDepdendenciesContext);
+}

--- a/src/shared/wrapWdkDependencies.ts
+++ b/src/shared/wrapWdkDependencies.ts
@@ -1,0 +1,31 @@
+import { WdkDependencies } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
+
+import { StudyAccessApi } from '../study-access/api';
+
+export interface WdkDependenciesWithStudyAccessApi extends WdkDependencies {
+  studyAccessApi: StudyAccessApi;
+}
+
+export function areCompatibleWdkDependencies(
+  wdkDependencies: WdkDependencies | undefined
+): wdkDependencies is WdkDependenciesWithStudyAccessApi {
+  return (
+    wdkDependencies != null &&
+    'studyAccessApi' in wdkDependencies
+  );
+}
+
+export function wrapWdkDependencies(
+  studyAccessApiUrl: string,
+  wdkDependencies: WdkDependencies
+): WdkDependenciesWithStudyAccessApi {
+  const studyAccessApi = new StudyAccessApi(
+    { baseUrl: studyAccessApiUrl },
+    wdkDependencies.wdkService
+  );
+
+  return {
+    ...wdkDependencies,
+    studyAccessApi
+  };
+}

--- a/src/study-access/EntityTypes.ts
+++ b/src/study-access/EntityTypes.ts
@@ -240,15 +240,19 @@ export const datasetProviderPatch = array(
 
 export type DatasetProviderPatch = TypeOf<typeof datasetProviderPatch>;
 
+export const actionAuthorization = type({
+  studyMetadata: boolean,
+  subsetting: boolean,
+  visualizations: boolean,
+  resultsFirstPage: boolean,
+  resultsAll: boolean,
+});
+
+export type ActionAuthorization = TypeOf<typeof actionAuthorization>;
+
 export const permissionEntryBase = type({
   studyId: string,
-  actionAuthorization: type({
-    studyMetadata: boolean,
-    subsetting: boolean,
-    visualizations: boolean,
-    resultsFirstPage: boolean,
-    resultsAll: boolean,
-  })
+  actionAuthorization
 });
 
 export type PermissionEntryBase = TypeOf<typeof permissionEntryBase>;

--- a/src/study-access/EntityTypes.ts
+++ b/src/study-access/EntityTypes.ts
@@ -240,16 +240,35 @@ export const datasetProviderPatch = array(
 
 export type DatasetProviderPatch = TypeOf<typeof datasetProviderPatch>;
 
-export const providerPermissionEntry = type({
-  type: literal('provider'),
-  isManager: boolean
+export const permissionEntryBase = type({
+  studyId: string,
+  actionAuthorization: type({
+    studyMetadata: boolean,
+    subsetting: boolean,
+    visualizations: boolean,
+    resultsFirstPage: boolean,
+    resultsAll: boolean,
+  })
 });
+
+export type PermissionEntryBase = TypeOf<typeof permissionEntryBase>;
+
+export const providerPermissionEntry = intersection([
+  permissionEntryBase,
+  type({
+    type: literal('provider'),
+    isManager: boolean
+  })
+]);
 
 export type ProviderPermissionEntry = TypeOf<typeof providerPermissionEntry>;
 
-export const endUserPermissionEntry = type({
-  type: literal('end-user')
-});
+export const endUserPermissionEntry = intersection([
+  permissionEntryBase,
+  type({ 
+    type: literal('end-user')
+  })
+]);
 
 export type EndUserPermissionEntry = TypeOf<typeof endUserPermissionEntry>;
 
@@ -260,11 +279,15 @@ export const datasetPermissionEntry = union([
 
 export type DatasetPermissionEntry = TypeOf<typeof datasetPermissionEntry>;
 
-export const permissionsResponse = partial({
-  isOwner: boolean,
-  isStaff: boolean,
-  perDataset: record(string, datasetPermissionEntry)
-});
+export const permissionsResponse = intersection([
+  type({
+    perDataset: record(string, datasetPermissionEntry)
+  }),
+  partial({
+    isOwner: boolean,
+    isStaff: boolean,
+  })
+]);
 
 export type PermissionsResponse = TypeOf<typeof permissionsResponse>;
 

--- a/src/study-access/EntityTypes.ts
+++ b/src/study-access/EntityTypes.ts
@@ -265,7 +265,7 @@ export type ProviderPermissionEntry = TypeOf<typeof providerPermissionEntry>;
 
 export const endUserPermissionEntry = intersection([
   permissionEntryBase,
-  type({ 
+  type({
     type: literal('end-user')
   })
 ]);

--- a/src/study-access/api.ts
+++ b/src/study-access/api.ts
@@ -26,11 +26,6 @@ import {
   staffList
 } from './EntityTypes';
 
-// FIXME: This should be configurable
-export const STUDY_ACCESS_SERVICE_URL = '/eda';
-
-export const StudyAccessServiceUrlContext = createContext(STUDY_ACCESS_SERVICE_URL);
-
 // API  defined in https://veupathdb.github.io/service-dataset-access/api.html
 const STAFF_PATH = '/staff';
 const PROVIDERS_PATH = '/dataset-providers';

--- a/src/study-access/api.ts
+++ b/src/study-access/api.ts
@@ -2,8 +2,7 @@ import { zipWith } from 'lodash';
 
 import {
   createJsonRequest,
-  ApiRequest,
-  FetchClient,
+  FetchClientWithCredentials,
   ioTransformer,
 } from '@veupathdb/http-utils';
 import {
@@ -35,19 +34,7 @@ const END_USERS_PATH = '/dataset-end-users';
 const PERMISSIONS_PATH = '/permissions';
 const HISTORY_PATH = '/history';
 
-export class StudyAccessApi extends FetchClient {
-
-  fetch = <T>(apiRequest: ApiRequest<T>) => {
-    const wdkCheckAuth = document.cookie.split('; ').find(x => x.startsWith('wdk_check_auth=')) ?? '';
-    const authKey = wdkCheckAuth.replace('wdk_check_auth=', '');  
-    return super.fetch({
-      ...apiRequest,
-      headers: {
-        ...apiRequest.headers,
-        'Auth-key': authKey
-      }
-    })
-  }
+export class StudyAccessApi extends FetchClientWithCredentials {
 
   fetchStaffList = (limit?: number, offset?: number) => {
     const queryString = makeQueryString(

--- a/src/study-access/api.ts
+++ b/src/study-access/api.ts
@@ -1,5 +1,3 @@
-import { createContext } from 'react';
-
 import { zipWith } from 'lodash';
 
 import {

--- a/src/study-access/api.ts
+++ b/src/study-access/api.ts
@@ -1,3 +1,5 @@
+import { createContext } from 'react';
+
 import { zipWith } from 'lodash';
 
 import {
@@ -25,7 +27,9 @@ import {
 } from './EntityTypes';
 
 // FIXME: This should be configurable
-export const STUDY_ACCESS_SERVICE_URL = '/dataset-access';
+export const STUDY_ACCESS_SERVICE_URL = '/eda';
+
+export const StudyAccessServiceUrlContext = createContext(STUDY_ACCESS_SERVICE_URL);
 
 // API  defined in https://veupathdb.github.io/service-dataset-access/api.html
 const STAFF_PATH = '/staff';

--- a/src/study-access/components/StudyAccessController.tsx
+++ b/src/study-access/components/StudyAccessController.tsx
@@ -5,7 +5,6 @@ import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 import { useSetDocumentTitle } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import NotFound from '@veupathdb/wdk-client/lib/Views/NotFound/NotFound';
 
-import { STUDY_ACCESS_SERVICE_URL } from '../api';
 import { canAccessDashboard } from '../permission';
 import { StudyAccess } from './StudyAccess';
 import {
@@ -33,7 +32,7 @@ export default function StudyAccessController({ datasetId }: Props) {
 
   const study = useStudy(datasetId);
 
-  const studyAccessApi = useStudyAccessApi(STUDY_ACCESS_SERVICE_URL);
+  const studyAccessApi = useStudyAccessApi();
 
   const { value: userPermissions } = useUserPermissions(studyAccessApi.fetchPermissions);
 

--- a/src/study-access/permission.ts
+++ b/src/study-access/permission.ts
@@ -12,7 +12,6 @@ import {
   PermissionsResponse
 } from './EntityTypes';
 import {
-  STUDY_ACCESS_SERVICE_URL,
   StudyAccessApi
 } from './api';
 
@@ -193,28 +192,19 @@ export function isUserFullyApprovedForStudy(
   );
 }
 
-async function fetchPermissions(
-  wdkService: WdkService,
-  fetchApi?: Window['fetch'],
-) {
-  const api = new StudyAccessApi(
-    { baseUrl: STUDY_ACCESS_SERVICE_URL, fetchApi },
-    wdkService
-  );
-
-  const permissionsResponse = await api.fetchPermissions();
+async function fetchPermissions(studyAccessApi: StudyAccessApi) {
+  const permissionsResponse = await studyAccessApi.fetchPermissions();
 
   return permissionsResponseToUserPermissions(permissionsResponse);
 }
 
 export async function checkPermissions(
   user: User,
-  wdkService: WdkService,
-  fetchApi?: Window['fetch'],
+  studyAccessApi: StudyAccessApi
 ): Promise<UserPermissions> {
   return user.properties?.approvedStudies == null
     ? { type: 'external', perDataset: {} }
-    : await fetchPermissions(wdkService, fetchApi);
+    : await fetchPermissions(studyAccessApi);
 }
 
 export function permittedApprovalStatusChanges(oldApprovalStatus: ApprovalStatus): ApprovalStatus[] {

--- a/src/study-access/permission.ts
+++ b/src/study-access/permission.ts
@@ -2,6 +2,11 @@ import { WdkService } from '@veupathdb/wdk-client/lib/Core';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
 import {
+  Action,
+  actionCategories
+} from '../data-restriction/DataRestrictionUiActions';
+
+import {
   ApprovalStatus,
   DatasetPermissionEntry,
   PermissionsResponse
@@ -145,6 +150,26 @@ export function canUpdateApprovalStatus(userPermissions: UserPermissions, datase
 
 export function shouldDisplayHistoryTable(userPermissions: UserPermissions) {
   return isOwner(userPermissions);
+}
+
+export function isUserApprovedForAction(
+  userPermissions: UserPermissions,
+  approvedStudies: string[] | undefined,
+  datasetId: string,
+  action: Action,
+) {
+  if (approvedStudies == null) {
+    return true;
+  }
+
+  const actionAuthorization =
+    userPermissions.perDataset[datasetId]?.actionAuthorization;
+
+  if (actionAuthorization == null) {
+    return false;
+  }
+
+  return actionAuthorization[actionCategories[action]];
 }
 
 export function isUserFullyApprovedForStudy(

--- a/src/study-access/permission.ts
+++ b/src/study-access/permission.ts
@@ -1,3 +1,4 @@
+import { WdkService } from '@veupathdb/wdk-client/lib/Core';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
 import {
@@ -174,18 +175,28 @@ export function isUserApprovedForStudy(
   );
 }
 
-async function fetchPermissions(fetchApi?: Window['fetch']) {
-  const api = new StudyAccessApi({ baseUrl: STUDY_ACCESS_SERVICE_URL, fetchApi });
+async function fetchPermissions(
+  wdkService: WdkService,
+  fetchApi?: Window['fetch'],
+) {
+  const api = new StudyAccessApi(
+    { baseUrl: STUDY_ACCESS_SERVICE_URL, fetchApi },
+    wdkService
+  );
 
   const permissionsResponse = await api.fetchPermissions();
 
   return permissionsResponseToUserPermissions(permissionsResponse);
 }
 
-export async function checkPermissions(user: User, fetchApi?: Window['fetch']): Promise<UserPermissions> {
-  return user.isGuest || user.properties?.approvedStudies == null
-    ? { type: 'none' }
-    : await fetchPermissions(fetchApi);
+export async function checkPermissions(
+  user: User,
+  wdkService: WdkService,
+  fetchApi?: Window['fetch'],
+): Promise<UserPermissions> {
+  return user.properties?.approvedStudies == null
+    ? { type: 'external', perDataset: {} }
+    : await fetchPermissions(wdkService, fetchApi);
 }
 
 export function permittedApprovalStatusChanges(oldApprovalStatus: ApprovalStatus): ApprovalStatus[] {

--- a/src/study-access/studyAccessHooks.tsx
+++ b/src/study-access/studyAccessHooks.tsx
@@ -9,8 +9,11 @@ import {
  } from 'lodash';
 
 import { IconAlt, SingleSelect } from '@veupathdb/wdk-client/lib/Components';
+import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
 import { usePromise } from '@veupathdb/wdk-client/lib/Hooks/PromiseHook';
+import { WdkDepdendenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { RecordInstance } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { OverflowingTextCell } from '@veupathdb/wdk-client/lib/Views/Strategy/OverflowingTextCell';
 
 import { ApprovalStatus, HistoryResult } from './EntityTypes';
@@ -45,7 +48,6 @@ import {
   Props as UserTableSectionConfig
 } from './components/UserTableSection';
 import { fetchStudies, getStudyId } from '../shared/studies';
-import { RecordInstance } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
 interface BaseTableRow {
   userId: number;
@@ -154,9 +156,14 @@ export function useStudyAccessApi(
   baseStudyAccessUrl: string,
   fetchApi?: Window['fetch']
 ) {
+  const { wdkService } = useNonNullableContext(WdkDepdendenciesContext);
+
   return useMemo(
     () => {
-      return new StudyAccessApi({ baseUrl: baseStudyAccessUrl, fetchApi });
+      return new StudyAccessApi(
+        { baseUrl: baseStudyAccessUrl, fetchApi },
+        wdkService
+      );
     },
     [ baseStudyAccessUrl, fetchApi ]
   );

--- a/src/study-access/studyAccessHooks.tsx
+++ b/src/study-access/studyAccessHooks.tsx
@@ -9,9 +9,7 @@ import {
  } from 'lodash';
 
 import { IconAlt, SingleSelect } from '@veupathdb/wdk-client/lib/Components';
-import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
 import { usePromise } from '@veupathdb/wdk-client/lib/Hooks/PromiseHook';
-import { WdkDepdendenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 import { RecordInstance } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { OverflowingTextCell } from '@veupathdb/wdk-client/lib/Views/Strategy/OverflowingTextCell';
@@ -48,6 +46,7 @@ import {
   Props as UserTableSectionConfig
 } from './components/UserTableSection';
 import { fetchStudies, getStudyId } from '../shared/studies';
+import { useWdkDependenciesWithStudyAccessApi } from '../shared/wdkDependencyHook';
 
 interface BaseTableRow {
   userId: number;
@@ -152,21 +151,8 @@ export function useStudy(datasetId: string): StudyStatus {
   );
 }
 
-export function useStudyAccessApi(
-  baseStudyAccessUrl: string,
-  fetchApi?: Window['fetch']
-) {
-  const { wdkService } = useNonNullableContext(WdkDepdendenciesContext);
-
-  return useMemo(
-    () => {
-      return new StudyAccessApi(
-        { baseUrl: baseStudyAccessUrl, fetchApi },
-        wdkService
-      );
-    },
-    [ baseStudyAccessUrl, fetchApi ]
-  );
+export function useStudyAccessApi() {
+  return useWdkDependenciesWithStudyAccessApi().studyAccessApi;
 }
 
 export function useUserPermissions(fetchPermissions: StudyAccessApi['fetchPermissions']) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,13 +2862,14 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/eslint-config/-/eslint-config-1.0.0.tgz#40dc855b263bd3fd68f8f61508ef55b1dc163caf"
   integrity sha512-UDgRQYsIdfB9KCkBmeqMjVQOQAAGB8RLFUj4KlLAxRcT5TlRI47ZmofB3/NMbpIHP27/pk1bryPo7z4DMwWyeQ==
 
-"@veupathdb/http-utils@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@veupathdb/http-utils/-/http-utils-1.0.0.tgz#44443bc34ab13b33373e1c80ac719c914a41e33d"
-  integrity sha512-NnqgLabaLxo75tGVG0RkB2DjWIkgE+1k12yOMtw4cuwZEqD+i4/M0RQVNPSQWPQVHRCR/c0pPZhJc20r8sMRhA==
+"@veupathdb/http-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@veupathdb/http-utils/-/http-utils-1.0.1.tgz#e3e2b616a43d82170c73e5ce44e80c740a960ee6"
+  integrity sha512-MURe3oXkK1ABOkVH94dK2NDBeh7KBphQUgjWNKAcn0ckT1+v5AUC8R7xkRd7P84wJT3inQE0vhEiItnoj6lYCg==
   dependencies:
     fp-ts "^2.11.5"
     io-ts "^2.2.16"
+    lodash "^4.17.21"
 
 "@veupathdb/prettier-config@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,10 +2892,10 @@
   resolved "https://registry.yarnpkg.com/@veupathdb/tsconfig/-/tsconfig-1.0.1.tgz#a2b748b46838af1337ca9f23d969993fb952def4"
   integrity sha512-i6gq7mgnyEN8/xW5EaI9RiWCwS1oB8cgWqx9h5w4vZtnb10oiyyepD640l9x/gZf6IWecjynRs7weDgSRs7l0Q==
 
-"@veupathdb/wdk-client@^0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.4.6.tgz#7dd8489dad185a6a3264761179235e091c983323"
-  integrity sha512-Ufxaq+N/Xo4PN9kzOvNzKmE6tbkxU/Q4VVGCP1nsCoFSxTN/G8dPWVRoDB3+mrBrjuzH5cqw4VIO1+viCVXCng==
+"@veupathdb/wdk-client@^0.4.12":
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/@veupathdb/wdk-client/-/wdk-client-0.4.12.tgz#13f32e85ac2cd7cfab306e265d2de480ed8697d7"
+  integrity sha512-MtopiFoDaGX7sFeaDQNWxVK413ua7DokgQ76AI33BT1ttOTp5JcL3Qg8f0WoQ3b1Vui2it98sMrivTIv9ADEiQ==
   dependencies:
     "@types/datatables.net" "^1.10.5"
     "@types/flot" "^0.0.31"


### PR DESCRIPTION
Depends on 

This PR:

1. Accommodates changes to the `/permissions` response. (At a high level, the `/permissions` response now indicates which categories of UI actions the user is permitted to perform, so lots of client-side data restriction checks are updated or excised.)
2. Uses the `/permissions` endpoint to enforce data restrictions for registered and guest users
3. Exposes a `WdkDependencies` wrapper which can be used to provide a configurable `StudyAccessApi` as a `WdkDependenciesContext` and a WDK epic/thunk dependency
4. Copies the `withPermissions` HOC from [EbrcWebsiteCommon](https://github.com/VEuPathDB/EbrcWebsiteCommon)

**Future work:**

Fully excise the use of the `approvedStudies` user property, which is still being used to handle the case of MicrobiomeDB.