### PR TITLE
Remove duplicate userId from fetch path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/study-data-access",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Utilities and hooks for controlling end user access to study data",
   "main": "lib/index.js",
   "repository": "git@github.com:VEuPathDB/web-study-data-access.git",

--- a/src/study-access/api.ts
+++ b/src/study-access/api.ts
@@ -142,7 +142,7 @@ export class StudyAccessApi extends FetchClientWithCredentials {
     );
 
     return this.fetch({
-      path: `${END_USERS_PATH}/${wdkUserId}-${endUserId}`,
+      path: `${END_USERS_PATH}/${endUserId}`,
       method: 'GET',
       transformResponse: ioTransformer(endUser)
     });


### PR DESCRIPTION
Removed `wdkUserId` from the line below because `endUserId` already includes it:

`path: '${END_USERS_PATH}/${wdkUserId}-${endUserId}',`