### PR TITLE
Fix Study Access Dashboard access for unreleased studies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/study-data-access",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Utilities and hooks for controlling end user access to study data",
   "main": "lib/index.js",
   "repository": "git@github.com:VEuPathDB/web-study-data-access.git",

--- a/src/shared/studies.ts
+++ b/src/shared/studies.ts
@@ -4,7 +4,7 @@ import { RecordInstance } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 export type Study = RecordInstance;
 
 export async function fetchStudies(wdkService: WdkService) {
-  const answer = await wdkService.getAnswerJson(
+  return await wdkService.getAnswerJson(
     {
       searchName: 'AllDatasets',
       searchConfig: { parameters: {} },
@@ -22,8 +22,6 @@ export async function fetchStudies(wdkService: WdkService) {
       tables: []
     }
   );
-
-  return answer;
 }
 
 export function getStudyId(record: RecordInstance) {

--- a/src/shared/studies.ts
+++ b/src/shared/studies.ts
@@ -4,7 +4,6 @@ import { RecordInstance } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 export type Study = RecordInstance;
 
 export async function fetchStudies(wdkService: WdkService) {
-  const { projectId } = await wdkService.getConfig();
   const answer = await wdkService.getAnswerJson(
     {
       searchName: 'AllDatasets',
@@ -19,15 +18,11 @@ export async function fetchStudies(wdkService: WdkService) {
         'policy_url',
         'request_needs_approval',
         'bulk_download_url',
-        'project_availability',
       ],
       tables: []
     }
   );
-  answer.records = answer.records.filter(record => {
-    const projectAvailability = getProjectAvailability(record);
-    return projectAvailability == null || projectAvailability.includes(projectId);
-  });
+
   return answer;
 }
 
@@ -53,11 +48,6 @@ export function getStudyPolicyUrl(record: RecordInstance) {
 
 export function getStudyRequestNeedsApproval(record: RecordInstance) {
   return getStringAttributeValue(record, 'request_needs_approval');
-}
-
-export function getProjectAvailability(record: RecordInstance) {
-  const value = getStringAttributeValue(record, 'project_availability');
-  return value == null ? null : JSON.parse(value) as string[];
 }
 
 function getStringAttributeValue(record: RecordInstance, attributeName: string) {


### PR DESCRIPTION
Resolves #15 

This PR updates the `fetchStudies` utility used "under the hood" by the [attemptAction](https://github.com/VEuPathDB/web-study-data-access/blob/92741a79c04eb6e2f17d850df1941edd6158d165/src/data-restriction/DataRestrictionActionCreators.ts#L23) action creator and the Study Access Dashboard's [useStudy hook](https://github.com/VEuPathDB/web-study-data-access/blob/61f10b97c7657c6dae7545b51222446f0014c7f4/src/study-access/studyAccessHooks.tsx#L133).

Now, the list of fetched studies is not filtered by `project_availability`, but simply returned as-is. This is necessary to accommodate a recent change to how we configured sites to [show[UnreleasedData]](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/119).

This change means:
1. `attemptAction` will not [skip](https://github.com/VEuPathDB/web-study-data-access/blob/92741a79c04eb6e2f17d850df1941edd6158d165/src/data-restriction/DataRestrictionActionCreators.ts#L69-L75) the "permissions" validation for unreleased studies (a good thing)
2. There will be a small UX deviation for the Study Access Dashboard: now "unapproved" users who try to visit the Study Access Dashboard for an unreleased study will receive a "permission denied" page (before, such users would receive a "Page Not Found," a [Glomar response](https://en.wikipedia.org/wiki/Glomar_response) for existence of the study).

In the future, we might consider giving the `fetchStudies` utility a `showUnreleasedData` parameter and tagging the fetched studies with a "hidden" / "disabled" flag as appropriate. That would allow us to preserve the "Glomar" UX for the Study Access Dashboard. I didn't do that here because it wasn't immediately clear how to renovate `attemptAction`. (Can't just pull in `showUnreleasedData` from `@veupathdb/web-common`, because that would introduce a circular dependency!)