### PR TITLE
Fix 21

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
   "author": "Dave Falke <dmfalke@gmail.com>",
   "license": "Apache-2.0",
   "scripts": {
-    "build-npm-modules": "veupathdb-react-scripts prepare src lib"
+    "build-npm-modules": "veupathdb-react-scripts prepare src lib",
+    "build": "veupathdb-react-scripts prepare src lib"
   },
   "typings": "./lib/index.d.ts",
+  "files": [
+    "lib",
+    "src/lib"
+  ],
   "eslintConfig": {
     "extends": [
       "@veupathdb"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/study-data-access",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Utilities and hooks for controlling end user access to study data",
   "main": "lib/index.js",
   "repository": "git@github.com:VEuPathDB/web-study-data-access.git",

--- a/src/data-restriction/permissionsHooks.ts
+++ b/src/data-restriction/permissionsHooks.ts
@@ -25,7 +25,7 @@ export function usePermissions(): AsyncUserPermissions {
 
   const permissions = useWdkService(
     async wdkService => memoizedPermissionsCheck(
-      await wdkService.getCurrentUser(),
+      await wdkService.getCurrentUser({ force: true }),
       studyAccessApi
     ),
     [studyAccessApi]


### PR DESCRIPTION
Fixes #21.

User datasets can be installed in the database at any point of a user's website session. Since we don't have a dedicated way to detect such events, this PR introduces a way to break the memoization cache such that we always request updated permissions from the backend. I opted not to remove the memoization itself with the thought that we might be able to leverage the WDK user service client module in some way to detect installed user datasets, and once again take advantage of memoization. A more robust fix might be to use a different approach to prevent multiple calls to the permissions endpoint, or to simply remove memoization. Since this is a somewhat urgent issue, I opted for a solution that introduces the least change. I will open an issue to explore this in a more robust way.