### PR TITLE
Only request dataset record attributes defined in the model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/study-data-access",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Utilities and hooks for controlling end user access to study data",
   "main": "lib/index.js",
   "repository": "git@github.com:VEuPathDB/web-study-data-access.git",

--- a/src/shared/studies.ts
+++ b/src/shared/studies.ts
@@ -14,21 +14,34 @@ const attributeNames = {
 };
 
 export async function fetchStudies(wdkService: WdkService) {
+  const datasetRecordClass = await wdkService.findRecordClass('dataset');
+
+  const requiredAttributes = [
+    attributeNames.DISPLAY_NAME,
+    attributeNames.DATASET_ID,
+    attributeNames.EMAIL,
+    attributeNames.BULK_DOWNLOAD_URL,
+  ];
+
+  const optionalAttributes = [
+    attributeNames.POLICY_URL,
+    attributeNames.REQUEST_NEEDS_APPROVAL,
+    attributeNames.STUDY_ACCESS,
+  ];
+
+  const attributes = requiredAttributes.concat(
+    optionalAttributes.filter(
+      (attr) => attr in datasetRecordClass.attributesMap
+    )
+  );
+
   return await wdkService.getAnswerJson(
     {
       searchName: 'AllDatasets',
       searchConfig: { parameters: {} },
     },
     {
-      attributes: [
-        attributeNames.DISPLAY_NAME,
-        attributeNames.DATASET_ID,
-        attributeNames.EMAIL,
-        attributeNames.BULK_DOWNLOAD_URL,
-        attributeNames.POLICY_URL,
-        attributeNames.REQUEST_NEEDS_APPROVAL,
-        attributeNames.STUDY_ACCESS,
-      ],
+      attributes,
       tables: [],
     }
   );

--- a/src/shared/studies.ts
+++ b/src/shared/studies.ts
@@ -3,6 +3,16 @@ import { RecordInstance } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
 export type Study = RecordInstance;
 
+const attributeNames = {
+  DISPLAY_NAME: 'display_name',
+  DATASET_ID: 'dataset_id',
+  EMAIL: 'email',
+  BULK_DOWNLOAD_URL: 'bulk_download_url',
+  POLICY_URL: 'policy_url',
+  REQUEST_NEEDS_APPROVAL: 'request_needs_approval',
+  STUDY_ACCESS: 'study_access',
+};
+
 export async function fetchStudies(wdkService: WdkService) {
   return await wdkService.getAnswerJson(
     {
@@ -11,44 +21,47 @@ export async function fetchStudies(wdkService: WdkService) {
     },
     {
       attributes: [
-        'display_name',
-        'dataset_id',
-        'study_access',
-        'email',
-        'policy_url',
-        'request_needs_approval',
-        'bulk_download_url',
+        attributeNames.DISPLAY_NAME,
+        attributeNames.DATASET_ID,
+        attributeNames.EMAIL,
+        attributeNames.BULK_DOWNLOAD_URL,
+        attributeNames.POLICY_URL,
+        attributeNames.REQUEST_NEEDS_APPROVAL,
+        attributeNames.STUDY_ACCESS,
       ],
-      tables: []
+      tables: [],
     }
   );
 }
 
 export function getStudyId(record: RecordInstance) {
-  return getStringAttributeValue(record, 'dataset_id');
+  return getStringAttributeValue(record, attributeNames.DATASET_ID);
 }
 
 export function getStudyName(record: RecordInstance) {
-  return getStringAttributeValue(record, 'display_name');
+  return getStringAttributeValue(record, attributeNames.DISPLAY_NAME);
 }
 
 export function getStudyAccess(record: RecordInstance) {
-  return getStringAttributeValue(record, 'study_access')?.toLowerCase();
+  return getStringAttributeValue(record, attributeNames.STUDY_ACCESS)?.toLowerCase();
 }
 
 export function getStudyEmail(record: RecordInstance) {
-  return getStringAttributeValue(record, 'email');
+  return getStringAttributeValue(record, attributeNames.EMAIL);
 }
 
 export function getStudyPolicyUrl(record: RecordInstance) {
-  return getStringAttributeValue(record, 'policy_url');
+  return getStringAttributeValue(record, attributeNames.POLICY_URL);
 }
 
 export function getStudyRequestNeedsApproval(record: RecordInstance) {
-  return getStringAttributeValue(record, 'request_needs_approval');
+  return getStringAttributeValue(record, attributeNames.REQUEST_NEEDS_APPROVAL);
 }
 
-function getStringAttributeValue(record: RecordInstance, attributeName: string) {
+function getStringAttributeValue(
+  record: RecordInstance,
+  attributeName: string
+) {
   const attributeValue = record.attributes[attributeName];
   if (typeof attributeValue === 'string') return attributeValue;
   return null;


### PR DESCRIPTION
This PR adds some defensive code to prevent requesting attributes that do no exist in the dataset record class.